### PR TITLE
Take previously added strategies.

### DIFF
--- a/AngularJSLibrary/__init__.py
+++ b/AngularJSLibrary/__init__.py
@@ -69,6 +69,7 @@ def is_boolean(item):
 class ngElementFinder(ElementFinder):
     def __init__(self, ignore_implicit_angular_wait=False):
         super(ngElementFinder, self).__init__()
+        self._strategies = self._s2l._element_finder._strategies
         self.ignore_implicit_angular_wait = ignore_implicit_angular_wait
 
     def find(self, browser, locator, tag=None):


### PR DESCRIPTION
In our work, we import the library AngularJSLibrary after the add of a location strategy. The AngularJSLibrary __init__ erase then our location strategy creating a new ElementFinder instance.
With this fix, we ensure that previously added strategies persist after the AngularJSLibrary import.