### PR TITLE
fix: replace SeleniumLibrary with Selenium2Library

### DIFF
--- a/AngularJSLibrary/__init__.py
+++ b/AngularJSLibrary/__init__.py
@@ -135,7 +135,7 @@ class ngElementFinder(ElementFinder):
 
     @property
     def _s2l(self):
-        return BuiltIn().get_library_instance('SeleniumLibrary')
+        return BuiltIn().get_library_instance('Selenium2Library')
 
 class AngularJSLibrary:
 
@@ -347,4 +347,4 @@ class AngularJSLibrary:
 
     @property
     def _s2l(self):
-        return BuiltIn().get_library_instance('SeleniumLibrary')
+        return BuiltIn().get_library_instance('Selenium2Library')


### PR DESCRIPTION
Problem:
  when I add library to RED, and run my test code as below, it report a error.

Test code:
```robot
*** Settings ***
Library         Selenium2Library
Library         AngularJSLibrary

*** Keywords ***
mykw
    log  hi!
*** Test Cases ***
myTest
    mykw
```

Error message:
```
[ ERROR ] Error in file '/Users/zhlin/eclipse-workspace/my-robot-project/my-test-suite.robot': Initializing test library 'AngularJSLibrary' with no arguments failed: No library 'SeleniumLibrary' found.
Traceback (most recent call last):
  File "/Users/zhlin/eclipse-workspace/my-robot-project/env/lib/python2.7/site-packages/AngularJSLibrary/__init__.py", line 178, in __init__
    self._s2l._element_finder = ngElementFinder(self.root_selector, ignore_implicit_angular_wait)
  File "/Users/zhlin/eclipse-workspace/my-robot-project/env/lib/python2.7/site-packages/AngularJSLibrary/__init__.py", line 90, in __init__
    super(ngElementFinder, self).__init__(self._s2l)
  File "/Users/zhlin/eclipse-workspace/my-robot-project/env/lib/python2.7/site-packages/AngularJSLibrary/__init__.py", line 138, in _s2l
    return BuiltIn().get_library_instance('SeleniumLibrary')
  File "/usr/local/lib/python2.7/site-packages/robot/libraries/BuiltIn.py", line 3263, in get_library_instance
    raise RuntimeError(unic(err))
```

Solution:
   according to README, it should use Selenium2Library, so I change SeleniumLibrary to Selenium2Library, and the error dismiss.
