### PR TITLE
extended errormessage root selector

### DIFF
--- a/AngularJSLibrary/__init__.py
+++ b/AngularJSLibrary/__init__.py
@@ -29,7 +29,7 @@ js_wait_for_angular = """
     var callback = function () {waiting = false;}
     var el = document.querySelector(arguments[0]);
     if (!el) {
-      throw new Error('Unable to find root selector using "' +
+      throw new Error('Unable to find root selector that is given by importing the library using "' +
                       arguments[0] +
                       '". Please refer to the AngularJS library documentation' +
                       ' for more information on how to resolve this error.')


### PR DESCRIPTION
The error that is trown when the default rootselector ng-app is used, is not realy clear about adjusting the way the library is imported:
"Keyword 'Element Text Should Be' failed after retrying for 30 seconds. The last error was: WebDriverException: Message: unknown error: Unable to find root selector using "[ng-app]". Please refer to the AngularJS library documentation for more information on how to resolve this error."

I made a smal adjustment to add: Unable to find root selector *that is given by importing the library* using